### PR TITLE
Improve repo processing speed and add HTML reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ terrawiz scan --org <organization> [options]
 
 - `--org <organization>`: **Required**. GitHub organization or user name
 - `--repo <repository>`: Specific repository name (if not provided, will search the entire organization)
-- `--format <format>`: Output format: json, csv, or table (default: table)
+- `--format <format>`: Output format: json, csv, table, or html (default: table)
 - `--output <filepath>`: Export results to specified file
 - `--debug`: Enable debug logging
 - `--max-repos <number>`: Maximum number of repositories to process
@@ -87,6 +87,11 @@ terrawiz scan --org myorg
 Scan an entire organization and export results to CSV:
 ```bash
 terrawiz scan --org myorg --format csv --output terraform-modules.csv
+```
+
+Generate an HTML report:
+```bash
+terrawiz scan --org myorg --format html --output report.html
 ```
 
 Search a specific repository and export as JSON:
@@ -131,6 +136,9 @@ Displays a human-readable summary with:
 - Version distribution
 - Source type statistics
 - Rate limit status
+
+### HTML Format
+Generates a self-contained web page with a table of modules and summary statistics.
 
 ## Technical Details
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,49 @@ dotenv.config();
 // Initialize the logger
 const logger = Logger.forComponent('Main');
 
+/** Generate a simple HTML report */
+function generateHtmlReport(result: {
+    metadata: any;
+    modules: ReturnType<TerraformParser['parseModules']>;
+    summary: Record<string, { count: number; versions: Record<string, number> }>;
+}): string {
+    const { metadata, modules, summary } = result;
+    const rows = modules.map(m =>
+        `<tr><td>${m.name}</td><td>${m.source}</td><td>${m.version || ''}</td><td>${m.repository}</td><td>${m.filePath}</td><td><a href="${m.fileUrl}#L${m.lineNumber}">${m.lineNumber}</a></td></tr>`
+    ).join('');
+    const summaryItems = Object.entries(summary)
+        .map(([src, info]) => `<li>${src} - ${info.count} use${info.count === 1 ? '' : 's'}</li>`)
+        .join('');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Terraform Module Report</title>
+    <style>
+        body{font-family:Arial,Helvetica,sans-serif;margin:1em;}
+        table{border-collapse:collapse;width:100%;}
+        th,td{border:1px solid #ccc;padding:4px;}
+        th{background:#eee;}
+    </style>
+</head>
+<body>
+    <h1>Terraform Module Usage Report</h1>
+    <p><strong>Owner:</strong> ${metadata.owner}</p>
+    <p><strong>Repository:</strong> ${metadata.repository}</p>
+    <p><strong>Modules found:</strong> ${metadata.moduleCount}</p>
+    <p><strong>Files analyzed:</strong> ${metadata.fileCount}</p>
+    <h2>Modules</h2>
+    <table>
+        <thead><tr><th>Name</th><th>Source</th><th>Version</th><th>Repository</th><th>File</th><th>Line</th></tr></thead>
+        <tbody>${rows}</tbody>
+    </table>
+    <h2>Summary</h2>
+    <ul>${summaryItems}</ul>
+</body>
+</html>`;
+}
+
 /**
  * Set up command line interface
  */
@@ -27,7 +70,7 @@ program
     .description('Scan and analyze Terraform modules in GitHub repositories')
     .requiredOption('--org <organization>', 'GitHub organization or user name')
     .option('--repo <repository>', 'Specific repository name (if not provided, will search the entire organization)')
-    .option('--format <format>', 'Output format: json, csv, or table (default: table)', 'table')
+    .option('--format <format>', 'Output format: json, csv, table, or html (default: table)', 'table')
     .option('--output <filepath>', 'Export results to specified file')
     .option('--debug', 'Enable debug logging')
     .option('--max-repos <number>', 'Maximum number of repositories to process')
@@ -117,6 +160,10 @@ program
                             const githubLink = `${m.fileUrl}#L${m.lineNumber}`;
                             return `"${m.source}","${m.sourceType}","${m.version || ''}","${m.repository}","${m.filePath}",${m.lineNumber},"${githubLink}"`;
                         }).join('\n');
+                    break;
+                case 'html':
+                case 'web':
+                    outputData = generateHtmlReport(result);
                     break;
                 case 'table':
                 default:

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -428,15 +428,26 @@ export class GitHubService {
             const terraformFiles: TerraformFile[] = [];
             let processedCount = 0;
 
-            for (const repository of repositories) {
-                processedCount++;
-                this.logger.info(`Processing repository ${processedCount}/${repositories.length}: ${repository.fullName}`);
+            const batchSize = 5; // limit concurrent requests
+            for (let i = 0; i < repositories.length; i += batchSize) {
+                const batch = repositories.slice(i, i + batchSize);
+                const batchResults = await Promise.all(batch.map(async (repository, idx) => {
+                    const repoIndex = i + idx + 1;
+                    this.logger.info(`Processing repository ${repoIndex}/${repositories.length}: ${repository.fullName}`);
+                    try {
+                        const files = await this.getTerraformFilesFromRepo(repository);
+                        return { files, repoIndex };
+                    } catch (error) {
+                        this.logger.errorWithStack(`Error processing repository ${repository.fullName}`, error as Error);
+                        return { files: [], repoIndex };
+                    }
+                }));
 
-                const files = await this.getTerraformFilesFromRepo(repository);
-                terraformFiles.push(...files);
-
-                // Show a summary of our progress so far
-                this.logger.info(`Progress: ${processedCount}/${repositories.length} repositories processed, ${terraformFiles.length} Terraform files found so far`);
+                for (const result of batchResults) {
+                    terraformFiles.push(...result.files);
+                    processedCount++;
+                    this.logger.info(`Progress: ${processedCount}/${repositories.length} repositories processed, ${terraformFiles.length} Terraform files found so far`);
+                }
             }
 
             this.logger.info(`Found a total of ${terraformFiles.length} Terraform files across ${repositories.length} repositories`);


### PR DESCRIPTION
## Summary
- process repositories in parallel to speed up searches
- add HTML output support with `--format html`
- document new format in README

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*